### PR TITLE
Bug fix/session claims user id doesnt exit

### DIFF
--- a/src/app/(root)/events/create/page.tsx
+++ b/src/app/(root)/events/create/page.tsx
@@ -1,13 +1,10 @@
 import EventForm from '@/components/shared/EventForm';
-import {auth} from '@clerk/nextjs';
+import {getSessionUserId} from "@/lib/actions/user.actions";
 
-const CreateEvent = () => {
-  const {sessionClaims} = auth();
-  const userId = sessionClaims?.userId;
-
+const CreateEvent = async () => {
+  const userId = await getSessionUserId();
 
   if (!userId) {
-
     return <h1>Error, no userId found</h1>;
   }
 

--- a/src/components/shared/NavItems.tsx
+++ b/src/components/shared/NavItems.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import {headerLinks} from '../../constants';
-import link from 'next/link';
+import {headerLinks} from '@/constants';
 import Link from 'next/link';
 import {usePathname} from 'next/navigation';
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import {authMiddleware} from '@clerk/nextjs';
 
 export default authMiddleware({
-  debug: true,
+  // debug: true, // Use to debug Auth issues
   publicRoutes: [
     '/',
     'events/:id',


### PR DESCRIPTION
## Description
This fixes an issue with the using the Clerk Webhook to create the user.
- When a new user is created, clerk's webhook fires an event to our API with User data
- A new user is created and then metadata in clerk is created with a new userId property.
- The current new session doesn't have the userId in the token, so we cannot create a new event or do anything as a logged-in user.

It's a major drawback of using a clerk. We have to somehow refresh the session token in the front end, but there doesn't seem to be an easy way to do this. So, I've worked around this by creating a helper method that checks if userId exists and, if not, fetches it from MongoDB. 

Fetching from the database does not use PK, so there could be some performance implications. However, it should only be done once for each user.


## Checklist

- [x] This does not have any known performance implications
- [x] There are no risks involved
- [ ] This does not require any new/updated documentation
- [ ] Tests have been created to cover new/updated code

## Merging

- [x] I promise to use Squash & Merge if this PR is going into `develop`
