### PR TITLE
Ignore apiroutes from intl routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-config-prettier": "^9.1.0",
         "jest": "^29.7.0",
         "mongodb-memory-server": "^10.1.2",
+        "node-mocks-http": "^1.16.2",
         "postcss": "^8",
         "prettier": "3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.8",
@@ -2944,6 +2945,28 @@
         "sqids": "^0.3.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -3961,6 +3984,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4205,6 +4240,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/dequal": {
@@ -5386,6 +5430,15 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fs.realpath": {
@@ -7402,11 +7455,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "license": "MIT"
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -7424,6 +7495,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7435,6 +7515,39 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -7872,6 +7985,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-mocks-http": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.16.2.tgz",
+      "integrity": "sha512-2Sh6YItRp1oqewZNlck3LaFp5vbyW2u51HX2p1VLxQ9U/bG90XV8JY9O7Nk+HDd6OOn/oV3nA5Tx5k4Rki0qlg==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.21 || ^5.0.0",
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
@@ -8154,6 +8300,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/path-exists": {
@@ -8729,6 +8884,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -9100,6 +9264,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -10102,6 +10286,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-config-prettier": "^9.1.0",
     "jest": "^29.7.0",
     "mongodb-memory-server": "^10.1.2",
+    "node-mocks-http": "^1.16.2",
     "postcss": "^8",
     "prettier": "3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.8",

--- a/src/i18n/routing.test.ts
+++ b/src/i18n/routing.test.ts
@@ -1,0 +1,26 @@
+import { routing } from './routing';
+import { createNavigation } from 'next-intl/navigation';
+
+describe('routing behavior', () => {
+  it('should return the correct default locale when no locale matches', () => {
+    const { defaultLocale } = routing;
+    expect(defaultLocale).toBe('en');
+  });
+
+  it('should support the defined locales', () => {
+    const { locales } = routing;
+    expect(locales).toContain('en');
+    expect(locales).toContain('es');
+  });
+});
+
+describe('navigation behavior', () => {
+  const { Link, redirect, usePathname, useRouter } = createNavigation(routing);
+
+  it('should create navigation components', () => {
+    expect(Link).toBeDefined();
+    expect(redirect).toBeDefined();
+    expect(usePathname).toBeDefined();
+    expect(useRouter).toBeDefined();
+  });
+});

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -12,7 +12,7 @@ jest.mock('@clerk/nextjs/server', () => ({
   },
 }));
 
-jest.mock('next-intl/middleware', () => () => (req: NextRequest) => {
+jest.mock('next-intl/middleware', () => () => () => {
   return NextResponse.next();
 });
 

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,69 @@
+import { createMocks } from 'node-mocks-http';
+import middleware from '@/middleware';
+import { NextFetchEvent, NextRequest, NextResponse } from 'next/server';
+
+jest.mock('@clerk/nextjs/server', () => ({
+  clerkMiddleware: (handler: unknown) => handler,
+  createRouteMatcher: (routes: string[]) => (req: NextRequest) => {
+    const url = new URL(` http://localhost:3000${req.url}`);
+    return routes.some((route) =>
+      new RegExp(route.replace(':local', '')).test(url.pathname)
+    );
+  },
+}));
+
+jest.mock('next-intl/middleware', () => () => (req: NextRequest) => {
+  return NextResponse.next();
+});
+
+describe('middleware', () => {
+  it('should protect protected routes', async () => {
+    const { req } = createMocks({
+      method: 'GET',
+      url: '/en/events/create',
+    });
+
+    const auth = {
+      ...createMocks().req,
+      protect: jest.fn(),
+    };
+
+    await middleware(auth, req as unknown as NextFetchEvent);
+
+    expect(auth.protect).toHaveBeenCalled();
+  });
+
+  it('should bypass i18n routing for API routes', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: '/api/uploadthing/some-endpoint',
+    });
+
+    const auth = {
+      ...createMocks().req,
+      protect: jest.fn(),
+    };
+
+    await middleware(auth, req as unknown as NextFetchEvent);
+
+    expect(auth.protect).not.toHaveBeenCalled();
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('should apply i18n routing for non-API routes', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: '/some-page',
+    });
+
+    const auth = {
+      ...createMocks().req,
+      protect: jest.fn(),
+    };
+
+    await middleware(auth, req as unknown as NextFetchEvent);
+
+    expect(auth.protect).not.toHaveBeenCalled();
+    expect(res._getStatusCode()).toBe(200);
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,7 +20,6 @@ export default clerkMiddleware(async (auth, req) => {
 
   // Exclude api/ routes from i18n routing
   if (isApiRoute(req)) {
-    console.log('API route accessed');
     return; // Let the API route handle the response
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,10 +8,21 @@ const isProtectedRoute = createRouteMatcher([
   ':local/profile',
 ]);
 
+// /api routes will handle their own auth if necessary
+const isApiRoute = createRouteMatcher(['/api/(.*)']);
+
 const handleI18nRouting = createMiddleware(routing);
 
 export default clerkMiddleware(async (auth, req) => {
-  if (isProtectedRoute(req)) await auth.protect();
+  if (isProtectedRoute(req)) {
+    await auth.protect();
+  }
+
+  // Exclude api/ routes from i18n routing
+  if (isApiRoute(req)) {
+    console.log('API route accessed');
+    return; // Let the API route handle the response
+  }
 
   return handleI18nRouting(req);
 });


### PR DESCRIPTION
## Description
- Accidentally created a problem with the next-intl implementation where we redirected all api/ routes.
- Fixes this issue, and also created some tests
<!-- Detail anything to help the review process, -->
<!-- your approach or anything you feel is useful! -->

## How to test
Run the tests!
- Also add a user and check that the Clerk webhook no longer redirects and a user is created
<!-- include some instructions to the reviewer to help test -->

## Checklist

- [x] This does not have any known performance implications
- [x] There are no risks involved
- [x] This does not require any new/updated documentation
- [x] Tests have been created to cover new/updated code

## Merging

- [x] I promise to use Squash & Merge if this PR is going into `develop`
